### PR TITLE
fix .data[0] to .item(), fix in test episode error variable should in…

### DIFF
--- a/omniglot/omniglot_train_few_shot.py
+++ b/omniglot/omniglot_train_few_shot.py
@@ -203,7 +203,7 @@ def main():
         relation_network_optim.step()
 
         if (episode+1)%100 == 0:
-                print("episode:",episode+1,"loss",loss.data[0])
+                print("episode:",episode+1,"loss",loss.item())
 
         if (episode+1)%5000 == 0:
 
@@ -238,6 +238,9 @@ def main():
 
                 _,predict_labels = torch.max(relations.data,1)
 
+
+                predict_labels = predict_labels.cuda()
+                test_labels = test_labels.cuda()
                 rewards = [1 if predict_labels[j]==test_labels[j] else 0 for j in range(CLASS_NUM*SAMPLE_NUM_PER_CLASS)]
 
                 total_rewards += np.sum(rewards)

--- a/omniglot/omniglot_train_one_shot.py
+++ b/omniglot/omniglot_train_one_shot.py
@@ -201,7 +201,7 @@ def main():
         relation_network_optim.step()
 
         if (episode+1)%100 == 0:
-                print("episode:",episode+1,"loss",loss.data[0])
+                print("episode:",episode+1,"loss",loss.item())
 
         if (episode+1)%5000 == 0:
 
@@ -233,6 +233,8 @@ def main():
                 relations = relation_network(relation_pairs).view(-1,CLASS_NUM)
 
                 _,predict_labels = torch.max(relations.data,1)
+                predict_labels = predict_labels.cuda()
+                test_labels = test_labels.cuda()
 
                 rewards = [1 if predict_labels[j]==test_labels[j] else 0 for j in range(CLASS_NUM)]
 


### PR DESCRIPTION
1. Pytorch's new version, do not support `loss.data[0]` form, we need to change it into `loss.item()`.
2. The origin code will generate error for `predict_labels` and ` test_labels` are not in GPU. So I fixed it.
3. After unzip the Omniglot Dataset, there still exist `.DStore` in dir `Alphabet_of_the_Magi`.

The code is clean and elegant, reading your code is my honor.

Vincent